### PR TITLE
Still dealing with the fallout from the bad SDK 7.0.200 release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,16 @@ RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 # end of install powershell
 
 FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+#############
+# temp fix due to sdk 7.0.201 using a preview version of msbuild
+# installing sdk 7.0.103 which doesn't have this problem
+#############
+RUN apk update && apk upgrade && apk add bash
+RUN wget https://dot.net/v1/dotnet-install.sh && chmod +x ./dotnet-install.sh
+ENV DOTNET_INSTALL_FOLDER=/usr/share/dotnet
+RUN ./dotnet-install.sh --version 7.0.103 --install-dir ${DOTNET_INSTALL_FOLDER}
+############# the above block can be deleted when the SDK issue has been resolved
+
 WORKDIR /markdown-link-check-log-parser
 COPY ["MarkdownLinkCheckLogParser/NuGet.Config", "MarkdownLinkCheckLogParser/"]
 COPY ["MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheckLogParserCli.csproj", "MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/"]


### PR DESCRIPTION
This PR updates the Dockerfile to install SDK 7.0.103 because a new image has been published that moved the SDK installed from 7.0.103 to 7.0.201. Due to the tag I'm using on the Dockerfile that latest image was picked up and broke the pipeline again

Related with:
- This PR is a continuation of the work from #17 
- dotnet/sdk#30624
- actions/setup-dotnet#383