### PR TITLE
Update to dotnet 8

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -20,7 +20,11 @@ jobs:
     name: Build and test
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # don't fail if one of the matrix jobs fails. Example: try to run the windows matrix even if the ubuntu matrix fails.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       SLN_DIR: MarkdownLinkCheckLogParser
       SLN_FILENAME: MarkdownLinkCheckLogParser.sln
@@ -93,7 +97,7 @@ jobs:
         }
     - name: Set run even if tests fail condition
       id: even-if-tests-fail
-      if: always()
+      if: matrix.os == 'ubuntu-latest' && always()
       run: |
         # Some of the steps below provide feedback on the test run and I want to run them even if
         # some of the previous steps failed. For that I need:
@@ -109,7 +113,7 @@ jobs:
         Write-Output "condition is set to $condition"
     - name: Generate code coverage report
       id: code-coverage-report-generator
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       run: |
         $testCoverageReportDir = $(Join-Path -Path ${{ steps.dotnet-test.outputs.test-coverage-dir }} -ChildPath "report")
         Write-Output "test-coverage-report-dir=$testCoverageReportDir" >> $env:GITHUB_OUTPUT
@@ -118,24 +122,26 @@ jobs:
           "-targetdir:$testCoverageReportDir" `
           -reportTypes:htmlInline
     - name: Upload code coverage report to artifacts
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}
         path: ${{ steps.code-coverage-report-generator.outputs.test-coverage-report-dir }}
     - name: Upload test results to artifacts
-      if: steps.even-if-tests-fail.outputs.condition == 'true' && always()
+      if: matrix.os == 'ubuntu-latest' && steps.even-if-tests-fail.outputs.condition == 'true' && always()
       uses: actions/upload-artifact@v3
       with:
         name: ${{ env.TEST_RESULTS_ARTIFACT_NAME }}
         path: ${{ steps.dotnet-test.outputs.test-results-dir }}
     - name: Upload test coverage to Codecov
+      if: matrix.os == 'ubuntu-latest'
       uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # even though it's not required for public repos it helps with intermittent failures caused by https://community.codecov.com/t/upload-issues-unable-to-locate-build-via-github-actions-api/3954, https://github.com/codecov/codecov-action/issues/598
         files: ${{ steps.dotnet-test.outputs.test-coverage-file }}
         fail_ci_if_error: true
     - name: Log Codecov info
+      if: matrix.os == 'ubuntu-latest'
       run: |
         $codeCoveUrl = "https://app.codecov.io/gh/${{ github.repository }}/"
         Write-Output "::notice title=Code coverage (${{ runner.os }})::Code coverage has been uploaded to Codecov at $codeCoveUrl. You can download the code coverage report from the workflow artifact named: ${{ env.CODE_COVERAGE_ARTIFACT_NAME }}."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# See https://hub.docker.com/_/microsoft-dotnet-runtime/ for list of tags for dotnet runtime
+# See https://hub.docker.com/_/microsoft-dotnet-sdk for list of tags for dotnet sdk
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 # install powershell as per https://docs.microsoft.com/en-us/powershell/scripting/install/install-alpine
-ARG PWSH_VERSION=7.3.6
+ARG PWSH_VERSION=7.4.0
 RUN apk add --no-cache \
     ca-certificates \
     less \
@@ -18,14 +20,14 @@ RUN apk add --no-cache \
     icu-libs \
     curl
 RUN apk -X https://dl-cdn.alpinelinux.org/alpine/edge/main add --no-cache lttng-ust
-RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-alpine-x64.tar.gz -o /tmp/powershell.tar.gz
+RUN curl -L https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell-${PWSH_VERSION}-linux-musl-x64.tar.gz -o /tmp/powershell.tar.gz
 RUN mkdir -p /opt/microsoft/powershell/7
 RUN tar zxf /tmp/powershell.tar.gz -C /opt/microsoft/powershell/7
 RUN chmod +x /opt/microsoft/powershell/7/pwsh
 RUN ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
 # end of install powershell
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS build
 WORKDIR /markdown-link-check-log-parser
 COPY ["MarkdownLinkCheckLogParser/NuGet.Config", "MarkdownLinkCheckLogParser/"]
 COPY ["MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheckLogParserCli.csproj", "MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/"]

--- a/MarkdownLinkCheckLogParser/.editorconfig
+++ b/MarkdownLinkCheckLogParser/.editorconfig
@@ -104,32 +104,22 @@ dotnet_diagnostic.CA2007.severity = none        # CA2007: Do not directly await 
 dotnet_diagnostic.CA2234.severity = silent      # CA2234: Pass System.Uri objects instead of strings
 
 ##########################################
-# Language Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules
+# .NET code refactoring options
+# https://learn.microsoft.com/en-us/visualstudio/ide/reference/code-styles-refactoring-options?view=vs-2022
 ##########################################
-# .NET Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#net-style-rules
 [*.cs]
-# Parentheses preferences
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
-# Expression-level preferences
-dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
-# Undocumented
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 
-# C# Style Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/language-rules#c-style-rules
+##########################################
+# Language and unnecessary rules
+# https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules
+##########################################
 [*.cs]
-# 'var' preferences
-dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
-csharp_style_var_for_built_in_types = true:warning
-csharp_style_var_when_type_is_apparent = true:warning
-csharp_style_var_elsewhere = true:warning
-# Expression-bodied members
+
+# Code-block preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#code-block-preferences
+dotnet_diagnostic.IDE0290.severity = silent             # Use primary constructor (IDE0290)
+
+# Expression-bodied members https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-bodied-members
 csharp_style_expression_bodied_methods = true:silent
 dotnet_diagnostic.IDE0022.severity = silent             # Use expression body for methods (IDE0022)
 csharp_style_expression_bodied_operators = true:silent
@@ -144,18 +134,27 @@ csharp_style_expression_bodied_lambdas = true:silent
 dotnet_diagnostic.IDE0053.severity = silent             # Use expression body for lambdas (IDE0053)
 csharp_style_expression_bodied_local_functions = true:silent
 dotnet_diagnostic.IDE0061.severity = silent             # Use expression body for local functions (IDE0061)
-# Expression-level preferences
+
+# Expression-level preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#expression-level-preferences
+dotnet_diagnostic.IDE0010.severity = silent     # Add missing cases to switch statement (IDE0010)
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_diagnostic.IDE0045.severity = suggestion # Use conditional expression for assignment (IDE0045)
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_diagnostic.IDE0046.severity = none       # Use conditional expression for return (IDE0046)
 dotnet_diagnostic.IDE0057.severity = none                # Use range operator (IDE0057)
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
 csharp_style_implicit_object_creation_when_type_is_apparent = false:silent
 dotnet_diagnostic.IDE0090.severity = suggestion          # Simplify new expression (IDE0090)
 
-##########################################
-# Unnecessary Code Rules
-# https://docs.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/unnecessary-code-rules
-##########################################
-[*.cs]
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
-dotnet_diagnostic.IDE0058.severity = silent     # Remove unnecessary expression value (IDE0058)
+# Parentheses preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#parentheses-preferences
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:suggestion
+
+# 'var' preferences https://learn.microsoft.com/en-gb/dotnet/fundamentals/code-analysis/style-rules/language-rules#var-preferences
+dotnet_diagnostic.IDE0008.severity = none               # IDE0008: Use explicit type instead of 'var'
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:warning
 
 ##########################################
 # Formatting Rules
@@ -498,7 +497,7 @@ dotnet_diagnostic.SA1006.severity = suggestion  # SA1006: Preprocessor keywords 
 dotnet_diagnostic.SA1007.severity = suggestion  # SA1007: Operator keyword should be followed by space
 dotnet_diagnostic.SA1008.severity = suggestion  # SA1008: Opening parenthesis should be spaced correctly
 dotnet_diagnostic.SA1009.severity = suggestion  # SA1009: Closing parenthesis should be spaced correctly
-dotnet_diagnostic.SA1010.severity = suggestion  # SA1010: Opening square brackets should be spaced correctly
+dotnet_diagnostic.SA1010.severity = none        # SA1010: Opening square brackets should be spaced correctly # TODO review this, temporarily disabled until https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3687 is resolved. Hopefully soon by merging https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/3729
 dotnet_diagnostic.SA1011.severity = suggestion  # SA1011: Closing square brackets should be spaced correctly
 dotnet_diagnostic.SA1012.severity = suggestion  # SA1012: Opening braces should be spaced correctly
 dotnet_diagnostic.SA1013.severity = suggestion  # SA1013: Closing braces should be spaced correctly

--- a/MarkdownLinkCheckLogParser/global.json
+++ b/MarkdownLinkCheckLogParser/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-      "version": "7.0.x",
+      "version": "8.0.x",
       "rollForward": "disable",
       "allowPrerelease": false
   }

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/JsonConsoleOutputFormat.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/JsonConsoleOutputFormat.cs
@@ -2,6 +2,11 @@ namespace MarkdownLinkCheckLogParserCli.CliCommands.ParseLog.Outputs;
 
 internal sealed class JsonConsoleOutputFormat : IOutputFormat
 {
+    private static readonly JsonSerializerOptions _serializeOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+    };
+
     private readonly IConsole _console;
 
     public JsonConsoleOutputFormat(IConsole console)
@@ -12,11 +17,7 @@ internal sealed class JsonConsoleOutputFormat : IOutputFormat
     public async Task WriteAsync(MarkdownLinkCheckOutput output)
     {
         output.NotNull();
-        var serializeOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-        };
-        var outputAsJson = JsonSerializer.Serialize(output, serializeOptions);
+        var outputAsJson = JsonSerializer.Serialize(output, _serializeOptions);
         await _console.Output.WriteLineAsync(outputAsJson);
     }
 }

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/JsonFileOutputFormat.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/JsonFileOutputFormat.cs
@@ -2,6 +2,11 @@ namespace MarkdownLinkCheckLogParserCli.CliCommands.ParseLog.Outputs;
 
 internal sealed class JsonFileOutputFormat : IOutputFormat
 {
+    private static readonly JsonSerializerOptions _serializeOptions = new JsonSerializerOptions
+    {
+        WriteIndented = true,
+    };
+
     private readonly IFile _file;
     private readonly OutputJsonFilepath _filepath;
 
@@ -14,11 +19,7 @@ internal sealed class JsonFileOutputFormat : IOutputFormat
     public async Task WriteAsync(MarkdownLinkCheckOutput output)
     {
         output.NotNull();
-        var serializeOptions = new JsonSerializerOptions
-        {
-            WriteIndented = true,
-        };
-        var outputAsJson = JsonSerializer.Serialize(output, serializeOptions);
+        var outputAsJson = JsonSerializer.Serialize(output, _serializeOptions);
         try
         {
             await _file.WriteAllTextAsync(filename: _filepath, text: outputAsJson);

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/Types/OutputOptions.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/Outputs/Types/OutputOptions.cs
@@ -2,12 +2,11 @@ namespace MarkdownLinkCheckLogParserCli.CliCommands.ParseLog.Outputs.Types;
 
 internal sealed class OutputOptions
 {
-    private readonly List<OutputOptionsTypes> _values;
+    private readonly List<OutputOptionsTypes> _values = [];
 
     public OutputOptions(string outputOptions)
     {
         outputOptions.NotNullOrWhiteSpace();
-        _values = new List<OutputOptionsTypes>();
         var outputOptionsSplit = outputOptions.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (outputOptionsSplit.Contains("step-json", StringComparer.InvariantCulture))
         {

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/ParseLogCommand.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/CliCommands/ParseLog/ParseLogCommand.cs
@@ -21,35 +21,35 @@ public class ParseLogCommand : ICommand
     [CommandOption(
         "auth-token",
         IsRequired = true,
-        Validators = new Type[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "GitHub token used to access workflow run logs.")]
     public string AuthToken { get; init; } = default!;
 
     [CommandOption(
         "repo",
         IsRequired = true,
-        Validators = new Type[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The repository for the workflow run in the format of {owner}/{repo}.")]
     public string Repo { get; init; } = default!;
 
     [CommandOption(
         "run-id",
         IsRequired = true,
-        Validators = new Type[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The unique identifier of the workflow run that contains the markdown link check step.")]
     public string RunId { get; init; } = default!;
 
     [CommandOption(
         "job-name",
         IsRequired = true,
-        Validators = new Type[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The name of the job that contains the markdown link check step.")]
     public string JobName { get; init; } = default!;
 
     [CommandOption(
         "step-name",
         IsRequired = true,
-        Validators = new Type[] { typeof(NotNullOrWhitespaceOptionValidator) },
+        Validators = [typeof(NotNullOrWhitespaceOptionValidator)],
         Description = "The name of the markdown link check step.")]
     public string StepName { get; init; } = default!;
 
@@ -58,7 +58,7 @@ public class ParseLogCommand : ICommand
 
     [CommandOption(
         "output",
-        Validators = new Type[] { typeof(OutputOptionValidator) },
+        Validators = [typeof(OutputOptionValidator)],
         Description = "How to output the markdown file check result. It must be one of or a comma separated list of the following values: step-json,step-md,file-json,file-md.")]
     public string OutputOptions { get; init; } = "step-json";
 

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/MarkdownFileCheck.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/MarkdownFileCheck.cs
@@ -2,12 +2,11 @@ namespace MarkdownLinkCheckLogParserCli.MarkdownLinkCheck;
 
 internal sealed class MarkdownFileCheck
 {
-    private readonly List<MarkdownLinkError> _errors;
+    private readonly List<MarkdownLinkError> _errors = [];
 
     public MarkdownFileCheck(string filename)
     {
         Filename = filename.NotNull();
-        _errors = new List<MarkdownLinkError>();
     }
 
     public string Filename { get; }

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/MarkdownLinkCheckOutput.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/MarkdownLinkCheckOutput.cs
@@ -7,8 +7,8 @@ internal sealed class MarkdownLinkCheckOutput
         files.NotNull();
         var orderedByFilename = files.OrderBy(x => x.Filename, StringComparer.InvariantCulture);
         Files = captureErrorsOnly
-            ? orderedByFilename.Where(x => x.HasErrors).ToList()
-            : orderedByFilename.ToList();
+            ? [.. orderedByFilename.Where(x => x.HasErrors)]
+            : [.. orderedByFilename];
         TotalFilesChecked = files.Count;
         TotalLinksChecked = files.Sum(x => x.LinksChecked);
         TotalErrors = files.Sum(x => x.ErrorCount);

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/ParserState.cs
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheck/ParserState.cs
@@ -5,7 +5,7 @@ namespace MarkdownLinkCheckLogParserCli.MarkdownLinkCheck;
 internal sealed class ParserState
 {
     private MarkdownFileCheck? _current;
-    private readonly List<MarkdownFileCheck> _files = new List<MarkdownFileCheck>();
+    private readonly List<MarkdownFileCheck> _files = [];
 
     public IReadOnlyList<MarkdownFileCheck> Files => _files;
 

--- a/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheckLogParserCli.csproj
+++ b/MarkdownLinkCheckLogParser/src/MarkdownLinkCheckLogParserCli/MarkdownLinkCheckLogParserCli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Auxiliary/LineEndings.cs
+++ b/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Auxiliary/LineEndings.cs
@@ -1,7 +1,17 @@
 namespace MarkdownLinkCheckLogParserCli.Tests.Auxiliary;
 
-internal static class LineEndings
+internal static partial class LineEndings
 {
+    // matchTimeoutMilliseconds used to prevent denial of service attacks. See MA0009 https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0009.md
+    // Adding 5 secs which for this scenario means: a random high enough value. It will probably work with much lower values but
+    // for this code this doesn't matter much as long as it's compliant with MA0009.
+    [GeneratedRegex(@"\r\n", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 5000)]
+    private static partial Regex WindowsNewLinesRegex();
+
+    // This pattern uses a negative lookbehind to ensure that the LF character is not preceded by a CR character.
+    [GeneratedRegex(@"(?<!\r)\n", RegexOptions.IgnoreCase, matchTimeoutMilliseconds: 5000)]
+    private static partial Regex LinuxNewLinesRegex();
+
     /// <summary>
     /// Updates a string so that the line endings match the OS expected line endings.
     /// </summary>
@@ -9,24 +19,18 @@ internal static class LineEndings
     /// <returns>A string containing line endings matching the OS expected line endings.</returns>
     public static string NormalizeLineEndings(this string original)
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT && original.Contains(CR + LF, StringComparison.InvariantCulture))
-        {
-            // if it's a Windows OS and contains Windows line endings then do nothing
-            return original;
-        }
-
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT && original.Contains(LF, StringComparison.InvariantCulture))
+        if (Environment.OSVersion.Platform == PlatformID.Win32NT && LinuxNewLinesRegex().IsMatch(original))
         {
             // if it's a Windows OS and doesn't contain Windows line endings then replace
             // new lines with Windows line endings
-            return original.Replace(LF, Environment.NewLine, StringComparison.InvariantCulture);
+            return LinuxNewLinesRegex().Replace(original, CR + LF);
         }
 
-        if (Environment.OSVersion.Platform == PlatformID.Unix && original.Contains(CR + LF, StringComparison.InvariantCulture))
+        if (Environment.OSVersion.Platform == PlatformID.Unix && WindowsNewLinesRegex().IsMatch(original))
         {
             // if it's a Linux OS and contains Windows line endings then replace
             // new lines with Linux line endings
-            return original.Replace(CR + LF, Environment.NewLine, StringComparison.InvariantCulture);
+            return WindowsNewLinesRegex().Replace(original, LF);
         }
 
         return original;

--- a/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Auxiliary/MarkdownCheckOutputTestModel.cs
+++ b/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Auxiliary/MarkdownCheckOutputTestModel.cs
@@ -5,7 +5,7 @@ internal sealed class MarkdownLinkCheckOutputJsonModel
 {
     public MarkdownLinkCheckOutputJsonModel()
     {
-        Files = new List<MarkdownFileCheckJsonModel>();
+        Files = [];
     }
 
     public int TotalFilesChecked { get; set; }
@@ -25,7 +25,7 @@ internal sealed class MarkdownFileCheckJsonModel
 {
     public MarkdownFileCheckJsonModel()
     {
-        Errors = new List<MarkdownLinkErrorJsonModel>();
+        Errors = [];
     }
 
     public string? Filename { get; set; }

--- a/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/MarkdownLinkCheckLogParserCli.Tests.csproj
+++ b/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/MarkdownLinkCheckLogParserCli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject> <!-- This shouldn't be needed because it should be added by the Microsoft.NET.Test.Sdk package but for now it's required as explained here https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198 -->
   </PropertyGroup>

--- a/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Usings.cs
+++ b/MarkdownLinkCheckLogParser/tests/MarkdownLinkCheckLogParserCli.Tests/Usings.cs
@@ -1,6 +1,7 @@
 global using System.Net;
 global using System.Text;
 global using System.Text.Json;
+global using System.Text.RegularExpressions;
 global using CliFx.Exceptions;
 global using CliFx.Extensibility;
 global using CliFx.Infrastructure;


### PR DESCRIPTION
- Update to use dotnet 8
- Fix some warnings
- Update pipeline to also build and run tests on windows. It turns out the tests were passing on linux but failing on windows.
- To fix the tests running on Windows I had to update the logic on the `LineEndings.NormalizeLineEndings` method. See comments below.