### PR TITLE
Move to StyleCop.Analyzers.Unstable

### DIFF
--- a/MarkdownLinkCheckLogParser/Directory.Build.props
+++ b/MarkdownLinkCheckLogParser/Directory.Build.props
@@ -61,7 +61,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="StyleCop.Analyzers">
+    <PackageReference Include="StyleCop.Analyzers.Unstable">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MarkdownLinkCheckLogParser/Directory.Packages.props
+++ b/MarkdownLinkCheckLogParser/Directory.Packages.props
@@ -15,7 +15,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.13.1" />
-    <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
The `StyleCop.Analyzers` package hasn't had a `stable` release since [version 1.1.118 in 2019](https://www.nuget.org/packages/StyleCop.Analyzers#versions-body-tab).

After reading DotNetAnalyzers/StyleCopAnalyzers#3826 and [this comment](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3647#issuecomment-1570708124) from DotNetAnalyzers/StyleCopAnalyzers#3647, I decided to adopt the usage of [StyleCop.Analyzers.Unstable](https://www.nuget.org/packages/StyleCop.Analyzers.Unstable) instead of using a beta version of [StyleCop.Analyzers](https://www.nuget.org/packages/StyleCop.Analyzers).