### PR TITLE
Updates to global.json and markdown-link-check action usage

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -20,5 +20,8 @@
       },
       "description": "Avoids 403s from GitHub docs"
     }
-  ]
+  ],
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "3s"
 }

--- a/.github/workflows/markdown-link-check-with-errors.yml
+++ b/.github/workflows/markdown-link-check-with-errors.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Markdown Link Check
       continue-on-error: true
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       with:
         config-file: .github/markdown-link-check-config.json
         folder-path: .github/workflows/markdown-link-check-files/with-errors/

--- a/.github/workflows/markdown-link-check-without-errors.yml
+++ b/.github/workflows/markdown-link-check-without-errors.yml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Markdown Link Check
       continue-on-error: true
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       with:
         config-file: .github/markdown-link-check-config.json
         folder-path: .github/workflows/markdown-link-check-files/without-errors/

--- a/.github/workflows/repo-markdown-link-check.yml
+++ b/.github/workflows/repo-markdown-link-check.yml
@@ -28,14 +28,14 @@ jobs:
       uses: actions/checkout@v4
     - name: Markdown link check
       id: mlc-push
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       if: github.event_name != 'pull_request'
       with:
         use-quiet-mode: yes
         config-file: .github/markdown-link-check-config-for-repo.json
     - name: Markdown link check
       id: mlc-pr
-      uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       if: github.event_name == 'pull_request'
       with:
         use-quiet-mode: yes

--- a/MarkdownLinkCheckLogParser/global.json
+++ b/MarkdownLinkCheckLogParser/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-      "version": "9.0.x",
-      "rollForward": "disable",
+      "version": "9.0.300",
+      "rollForward": "latestMinor",
       "allowPrerelease": false
   }
 }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Markdown Link Check
-      uses: gaurav-nelson/github-action-markdown-link-check@v1
+      uses: gaurav-nelson/github-action-markdown-link-check@1.0.17
       with:
         use-quiet-mode: no
 ```


### PR DESCRIPTION
- Added retry logic to handle 429 errors from github due to [rate limiting](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit). Updated markdown-link-check config as per [its docs](https://github.com/gaurav-nelson/github-action-markdown-link-check/tree/1.0.17/?tab=readme-ov-file#too-many-requests).
- Updated the `markdown-link-check` action to the latest version 1.0.17.
- Fixed the global.json which was being silently ignored by the dotnet build command because it contained a wildcard. As [per the docs](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json#version): `Doesn't have wildcard support; that is, you must specify the full version number.`