### PR TITLE
Delete global.json

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
-        global-json-file: MarkdownLinkCheckLogParser/global.json
+        dotnet-version: '9.x'
     - name: Cache/Restore NuGets
       uses: actions/cache@v4
       with:

--- a/docs/dev-notes/README.md
+++ b/docs/dev-notes/README.md
@@ -73,10 +73,6 @@ mlc-log-parser parse-log `
 
 - There is a set of NuGet packages that are only applied in test projects by using the condition `"'$(IsTestProject)' == 'true'"`. To make this work the `csproj` for the test projects must have the `<IsTestProject>true</IsTestProject>` property defined. Adding this property manually shouldn't be needed because it should be added by the `Microsoft.NET.Test.Sdk` package however there seems to be an issue with this when running tests outside of Visual Studio. See [this GitHub issue](https://github.com/dotnet/sdk/issues/3790#issuecomment-1100773198) for more info.
 
-- When running `dotnet` CLI commands make sure you are at the `/MarkdownLinkCheckLogParser` folder so that the `global.json` is respected. If you don't you might get unexpected results when building the solution. As explained in [global.json overview](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json):
-
-> The .NET SDK looks for a global.json file in the current working directory (which isn't necessarily the same as the project directory) or one of its parent directories.
-
 ## Deterministic Build configuration
 
 Following the guide from [Deterministic Builds](https://github.com/clairernovotny/DeterministicBuilds) the `ContinuousIntegrationBuild` setting on the [Directory.Build.props](/MarkdownLinkCheckLogParser/Directory.Build.props) is set to true, if the build is being executed in GitHub actions.


### PR DESCRIPTION
Updates the .NET SDK version used in the build process to version 9.x.

Removes the note in the dev notes about the importance of running `dotnet` commands at the `/MarkdownLinkCheckLogParser` folder since `global.json` is no longer being used.
